### PR TITLE
Request to Merge

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -109,7 +109,7 @@ class DefaultStateUpdaterTest {
     private final StreamsConfig config = new StreamsConfig(configProps(COMMIT_INTERVAL));
     private final ChangelogReader changelogReader = mock(ChangelogReader.class);
     private final TopologyMetadata topologyMetadata = unnamedTopology().build();
-    private DefaultStateUpdater stateUpdater =
+    private final DefaultStateUpdater stateUpdater =
         new DefaultStateUpdater("test-state-updater", metrics, config, null, changelogReader, topologyMetadata, time);
 
     @AfterEach
@@ -324,14 +324,15 @@ class DefaultStateUpdaterTest {
     public void shouldRestoreSingleActiveStatefulTask() throws Exception {
         final StreamTask task =
             statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
+        final AtomicBoolean allChangelogCompleted = new AtomicBoolean(false);
         when(changelogReader.completedChangelogs())
             .thenReturn(Collections.emptySet())
             .thenReturn(Set.of(TOPIC_PARTITION_A_0))
-            .thenReturn(Set.of(TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0));
-        when(changelogReader.allChangelogsCompleted())
-            .thenReturn(false)
-            .thenReturn(false)
-            .thenReturn(true);
+            .thenAnswer(invocation -> {
+                allChangelogCompleted.set(true);
+                return Set.of(TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0);
+            });
+        when(changelogReader.allChangelogsCompleted()).thenAnswer(invocation -> allChangelogCompleted.get());
         stateUpdater.start();
 
         stateUpdater.add(task);
@@ -362,7 +363,7 @@ class DefaultStateUpdaterTest {
                 allChangelogCompleted.set(true);
                 return Set.of(TOPIC_PARTITION_C_0, TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0);
             });
-        when(changelogReader.allChangelogsCompleted()).thenReturn(allChangelogCompleted.get());
+        when(changelogReader.allChangelogsCompleted()).thenAnswer(invocation -> allChangelogCompleted.get());
         stateUpdater.start();
 
         stateUpdater.add(task1);


### PR DESCRIPTION
### **PR Type**
bug_fix, tests


___

### **Description**
- Fixed flakiness in the `shouldRestoreSingleActiveStatefulTask` unit test by ensuring proper synchronization between changelog completion checks.
- Made the `stateUpdater` variable final to ensure consistent initialization.
- Used `AtomicBoolean` to track the completion status of all changelogs, improving test reliability.
- Updated the stubbing of `changelogReader.completedChangelogs()` and `changelogReader.allChangelogsCompleted()` to depend on each other, ensuring accurate test conditions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DefaultStateUpdaterTest.java</strong><dd><code>Fix flakiness in DefaultStateUpdaterTest unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java

<li>Made <code>stateUpdater</code> a final variable for consistency.<br> <li> Introduced <code>AtomicBoolean</code> to track changelog completion status.<br> <li> Updated stubbing of <code>changelogReader</code> methods to fix test flakiness.<br> <li> Improved synchronization between changelog completion checks.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/kafka/pull/3/files#diff-b66026ae7a508e612ec3cce6b4de88b2c4b43301b983eaaf7a9e63719dde8272">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information